### PR TITLE
Fixes compilation error (strnicmp not found)

### DIFF
--- a/os_dep/linux/rtw_android.c
+++ b/os_dep/linux/rtw_android.c
@@ -337,7 +337,7 @@ int rtw_android_cmdstr_to_num(char *cmdstr)
 {
 	int cmd_num;
 	for(cmd_num=0 ; cmd_num<ANDROID_WIFI_CMD_MAX; cmd_num++)
-		if(0 == strnicmp(cmdstr , android_wifi_cmd_str[cmd_num], strlen(android_wifi_cmd_str[cmd_num])) )
+		if(0 == strncmp(cmdstr , android_wifi_cmd_str[cmd_num], strlen(android_wifi_cmd_str[cmd_num])) )
 			break;
 
 	return cmd_num;


### PR DESCRIPTION
gcc output:
/home/meeuw/git/rtl8192eu/os_dep/linux/rtw_android.c: In functie ‘rtw_android_cmdstr_to_num’:
/home/meeuw/git/rtl8192eu/os_dep/linux/rtw_android.c:340:11: fout: impliciete declaratie van functie ‘strnicmp’ [-Werror=implicit-function-declaration]
   if(0 == strnicmp(cmdstr , android_wifi_cmd_str[cmd_num], strlen(android_wifi_cmd_str[cmd_num])) )
           ^
cc1: sommige waarschuwingen worden als fouten behandeld
scripts/Makefile.build:258: recept voor doel '/home/meeuw/git/rtl8192eu/os_dep/linux/rtw_android.o' is mislukt
